### PR TITLE
Escape class name components

### DIFF
--- a/jarjar-core/src/main/java/com/tonicsystems/jarjar/transform/config/PatternUtils.java
+++ b/jarjar-core/src/main/java/com/tonicsystems/jarjar/transform/config/PatternUtils.java
@@ -35,6 +35,26 @@ public class PatternUtils {
         return pattern.matcher(value).replaceAll(Matcher.quoteReplacement(replace));
     }
 
+
+    @Nonnull
+    private static String escapeComponents(String s) {
+        String[] parts = s.split("\\.");
+        StringBuilder b = new StringBuilder();
+
+        for (int i = 0; i < parts.length; i++) {
+            if (i != 0)
+                b.append('.');
+
+            if (parts[i].contains("*"))
+                b.append(parts[i]);
+            else
+                b.append(Pattern.quote(parts[i]));
+        }
+
+        return b.toString();
+    }
+
+
     @Nonnull
     public static Pattern newPattern(@Nonnull String pattern) {
         if (pattern.equals("**"))
@@ -44,7 +64,7 @@ public class PatternUtils {
         if (pattern.indexOf("***") >= 0)
             throw new IllegalArgumentException("The sequence '***' is invalid in a package pattern");
 
-        String regex = pattern;
+        String regex = escapeComponents(pattern);
         regex = replaceAllLiteral(regex, dstar, "(.+?)");   // One wildcard test requires the argument to be allowably empty.
         regex = replaceAllLiteral(regex, star, "([^/]+)");
         regex = replaceAllLiteral(regex, estar, "*\\??)");  // Although we replaced with + above, we mean *


### PR DESCRIPTION
This PR proposes to escape the class name components prior to passing them to regexes.

For standard / usual class names, this shouldn't change the current behavior.

For class names having non standard characters (`$` in particular), this allows to shade these with jarjar. Without this PR, these are currently simply not escaped (as the `$` signs get interpreted as end-of-line from the regexes).

I'm kind of new to this codebase, any direction would be welcome about where and how to add non regression tests for these (unless I'm mistaken, I couldn't find a comprehensive test suite in the current code).